### PR TITLE
Restore code coverage

### DIFF
--- a/include/libmodules/emitter.hpp
+++ b/include/libmodules/emitter.hpp
@@ -21,12 +21,20 @@ License.
 
 #include <vector>
 #include <algorithm>
+#include <stdexcept>
 
 namespace mtl
 {
     // This file is to implement signal transmission feature. Please see signal.hpp for details.
     // This file contains Emitter template implementation that emit signals to attached
     // transmitters.
+
+    class transmitter_not_attached
+        : public std::logic_error
+    {
+    public:
+        using std::logic_error::logic_error;
+    };
 
     template<typename signal_table>
     class emitter
@@ -61,7 +69,7 @@ namespace mtl
         {
             auto it = std::find(_transmitters.rbegin(), _transmitters.rend(), &transmitter);
             if (it == _transmitters.rend())
-                return;
+                throw transmitter_not_attached("Unable to detach transmitter that was not attached.");
 
             // Handle spy pointer to self instance to cleanup transmitters list at the end of all
             // recursive broadcasting and detaching processes.

--- a/include/libmodules/signal.hpp
+++ b/include/libmodules/signal.hpp
@@ -20,6 +20,7 @@ License.
 #include "spy_pointer.hpp"
 
 #include <functional>
+#include <stdexcept>
 
 namespace mtl
 {
@@ -46,6 +47,13 @@ namespace mtl
     // You can attach multiple receivers to one emitter or one receiver to multiple emitters.
     // Multiple inheritance could be used to receive signals from emitters of different types.
     // Method send could return false in case if emitter instance is destroyed while sending.
+
+	class invalid_transmitter
+        : public std::logic_error
+    {
+    public:
+        using std::logic_error::logic_error;
+    };
 
     template<typename signal_table>
     using packed_signal = std::function<void(signal_table&)>;
@@ -75,7 +83,7 @@ namespace mtl
         virtual void transmit_signal(const packed_signal<signal_table>& call)
         {
             if (!_receiver)
-                return;
+                throw invalid_transmitter("Unable to transmit packed signal by invalid transmitter.");
 
             call(*_receiver);
         }

--- a/test/emitter_test.cpp
+++ b/test/emitter_test.cpp
@@ -99,6 +99,14 @@ TEST(emitting, can_attach_and_detach_receivers)
     EXPECT_TRUE(r2.empty());
 }
 
+TEST(emitting, unable_to_detach_not_attached_receiver)
+{
+    emitter<test_emitter_signals> em;
+    test_receiver r;
+
+    EXPECT_THROW(em.detach(r), transmitter_not_attached);
+}
+
 TEST(emitting, emitter_copies_attachments)
 {
     emitter<test_emitter_signals> em1;


### PR DESCRIPTION
#Brief description

The code coverage was restored. Two more tests were added to check corner cases.

The invalid situations now throw errors.