### PR TITLE
Core guidelines in spy

### DIFF
--- a/include/libmodules/emitter.hpp
+++ b/include/libmodules/emitter.hpp
@@ -47,7 +47,7 @@ namespace mtl
 
         std::vector<spy_pointer<transmitter_type>> _transmitters;
 
-        void on_spying_state_changed()
+        void on_spying_state_changed() noexcept
         {
             // Do nothing in case if new broadcasting loop begins.
             if (sending())

--- a/include/libmodules/linked_list.hpp
+++ b/include/libmodules/linked_list.hpp
@@ -53,12 +53,12 @@ namespace mtl
     // The linked object have to inherit from the linked list class to enable required
     // functionality.  The linked list takes object type as a template parameter to hide static
     // cast and increase usability.
-    template<typename T>
+    template<typename object_type>
     class enable_linking_in_list
     {
     public:
-        using type = enable_linking_in_list<T>;
-        using next_pointer = T*;
+        using type = enable_linking_in_list<object_type>;
+        using next_pointer = object_type*;
         using prev_pointer = next_pointer*;
         using reference    = type&;
         using rvalue       = type&&;
@@ -70,7 +70,7 @@ namespace mtl
         explicit enable_linking_in_list(next_pointer& list) noexcept
         {
             // This assert is placed here to delay check until parent object is created.
-            static_assert(std::is_base_of<enable_linking_in_list<T>, T>::value,
+            static_assert(std::is_base_of<enable_linking_in_list<object_type>, object_type>::value,
                           "enable_linking_in_list should be base of template parameter type");
             // Place self into the list head
             _prev = &list;
@@ -142,8 +142,8 @@ namespace mtl
         prev_pointer _prev{nullptr};
     }; // class enable_linking_in_list
 
-    template<typename T>
-    void swap(enable_linking_in_list<T> first, enable_linking_in_list<T> second) noexcept
+    template<typename object_type>
+    void swap(enable_linking_in_list<object_type> first, enable_linking_in_list<object_type> second) noexcept
     {
         first.swap(second);
     }

--- a/include/libmodules/spy_pointer.hpp
+++ b/include/libmodules/spy_pointer.hpp
@@ -18,6 +18,7 @@ License.
 #pragma once
 
 #include "linked_list.hpp"
+
 #include <utility>
 
 namespace mtl
@@ -45,55 +46,49 @@ namespace mtl
     template<typename T>
     class enable_spying
     {
-        // Pointers should be able to add itself in the linked list
-        template<typename PointerType, typename Base>
-        friend class spy_pointer;
+    public:
+        bool empty() noexcept { return !_list_head; }
 
-        // List head could be modified in constant object
-        mutable spy_pointer<T>* _list_head = nullptr;
+        // Release all pointers that reference this object and stored in the linked list
+        void clear() noexcept;
 
     protected:
         // Constructors, destructor and copy operators has nothing specific. They take no ownership
         // of linked list from other object, but clears other object in case if it was moved. It
         // means that spy pointer operates like regular pointer and do not follow to object if it
         // was copied or moved.
-        enable_spying() = default;
-        enable_spying(const enable_spying<T>&  other) {}
-        enable_spying(      enable_spying<T>&& other) { other.clear(); }
-        virtual ~enable_spying() { clear(); }
+        enable_spying() noexcept = default;
+        ~enable_spying() noexcept { clear(); }
+        explicit enable_spying(const enable_spying<T>&other) noexcept {}
+        explicit enable_spying(enable_spying<T> && other) noexcept { other.clear(); }
 
-        enable_spying<T>& operator =(const enable_spying<T>&  other) {                return *this; }
-        enable_spying<T>& operator =(      enable_spying<T>&& other) { other.clear(); return *this; }
+        enable_spying<T>& operator =(const enable_spying<T>&other) noexcept { return *this; }
+        enable_spying<T>& operator =(enable_spying<T> && other) noexcept { other.clear(); return *this; }
 
         // Child type could by notified when it has new spy or lose the last one. It could overload
         // this signal to perform some specific actions.
-        virtual void on_spying_state_changed() {}
+        //
+        // Note: this function is executed in destructor of friend class. So, it should not throw.
+        virtual void on_spying_state_changed() noexcept {}
 
-    public:
-        bool empty() { return !_list_head; }
+    private:
+        // Pointers should be able to add itself in the linked list
+        template<typename PointerType, typename Base>
+        friend class spy_pointer;
 
-        // Release all pointers that reference this object and stored in the linked list
-        void clear();
+        // List head could be modified in constant object
+        mutable spy_pointer<T>* _list_head = nullptr;
     };
 
     template<typename T, typename Base>
-    class spy_pointer
+    class spy_pointer final
         : private enable_linking_in_list<spy_pointer<Base>>
     {
-        using base_type = enable_linking_in_list<spy_pointer<Base>>;
-
-        // Pointers could point to different type casts of one object
-        template<typename other_type, typename OtherBase>
-        friend class spy_pointer;
-        // Object should be able to release the pointer and exclude it from the list
-        friend base_type;
-
-        T* _p_object = nullptr;
-
     public:
+        using base_type = enable_linking_in_list<spy_pointer<Base>>;
         using type = spy_pointer<T, Base>;
 
-        spy_pointer(T* p_object = nullptr)
+        spy_pointer(T* p_object = nullptr) noexcept
             : _p_object(p_object)
         {
             if (!_p_object)
@@ -107,7 +102,7 @@ namespace mtl
                 tmp->on_spying_state_changed();
         }
 
-        ~spy_pointer()
+        ~spy_pointer() noexcept
         {
             if (!_p_object)
                 return;
@@ -124,11 +119,11 @@ namespace mtl
         }
 
         template<typename other_type>
-        type& swap(spy_pointer<other_type, Base>& other)
+        type& swap(spy_pointer<other_type, Base>& other) noexcept
         {
             // Swap linked lists
             base_type::swap(other);
-            // THen swap pointers
+            // Then swap pointers
             enable_spying<Base>* tmp = _p_object;
             _p_object = static_cast<T*>(other._p_object);
             other._p_object = static_cast<other_type*>(tmp);
@@ -137,46 +132,55 @@ namespace mtl
         }
 
         // The rest of copy constructors, copy operators and other operations
-        spy_pointer(     const type&  other) :                          spy_pointer(other._p_object) {}
+        explicit spy_pointer(const type&  other) noexcept : spy_pointer(other._p_object) {}
         template<typename other_type>
-        spy_pointer(const      spy_pointer<other_type, Base>&  other) : spy_pointer(static_cast<T*>(other._p_object)) {}
+        explicit spy_pointer(const spy_pointer<other_type, Base>&  other) noexcept : spy_pointer(static_cast<T*>(other._p_object)) {}
 
-        spy_pointer(           type&& other) {                                                             swap(other); }
+        explicit spy_pointer(type&& other) noexcept { swap(other); }
         template<typename other_type>
-        spy_pointer(           spy_pointer<other_type, Base>&& other) {                                    swap(other); }
+        explicit spy_pointer(spy_pointer<other_type, Base>&& other) noexcept { swap(other); }
 
-        type& operator =(const type&  other) { type tmp(other);                                     return swap(tmp); }
-        type& operator =(      type&& other) { type tmp(std::move(other));                          return swap(tmp); }
+        type& operator =(const type&  other) noexcept { type tmp(other);                                     return swap(tmp); }
+        type& operator =(      type&& other) noexcept { type tmp(std::move(other));                          return swap(tmp); }
         template<typename other_type>
-        type& operator =(const spy_pointer<other_type, Base>&  other) { type tmp(other);            return swap(tmp); }
+        type& operator =(const spy_pointer<other_type, Base>&  other) noexcept { type tmp(other);            return swap(tmp); }
         template<typename other_type>
-        type& operator =(      spy_pointer<other_type, Base>&& other) { type tmp(std::move(other)); return swap(tmp); }
+        type& operator =(      spy_pointer<other_type, Base>&& other) noexcept { type tmp(std::move(other)); return swap(tmp); }
 
         template<typename other_type>
-        operator spy_pointer<other_type, Base>() const { return spy_pointer<other_type, Base>(*this); }
+        operator spy_pointer<other_type, Base>() const noexcept { return spy_pointer<other_type, Base>(*this); }
 
-        type& reset(     T* p_object = nullptr) { type tmp(p_object); return swap(tmp); }
-        type& operator =(T* p_object)           { return reset(p_object); }
+        type& reset(     T* p_object = nullptr) noexcept { type tmp(p_object); return swap(tmp); }
+        type& operator =(T* p_object)           noexcept { return reset(p_object); }
         
-        operator bool() const { return !!_p_object; }
-        T* operator->() const { return   _p_object; }
-        T& operator *() const { return  *_p_object; }
-        T* get()        const { return   _p_object; }
-        operator   T*() const { return   _p_object; }
+        operator bool() const noexcept { return !!_p_object; }
+        T* operator->() const noexcept { return   _p_object; }
+        T& operator *() const noexcept { return  *_p_object; }
+        T* get()        const noexcept { return   _p_object; }
+        operator   T*() const noexcept { return   _p_object; }
 
-        template<typename other_type>
-        bool operator ==(spy_pointer<other_type, Base>& other)
-        {
-            return static_cast<enable_spying<Base>*>(_p_object) == static_cast<enable_spying<Base>*>(other._p_object);
-        }
+    private:
+        // Pointers could point to different type casts of one object
+        template<typename other_type, typename OtherBase>
+        friend class spy_pointer;
+        // Object should be able to release the pointer and exclude it from the list
+        friend base_type;
+
+        T* _p_object = nullptr;
     };
 
     // The clear method has to be defined after the spy_pointer class definition to be able access
     // it's members.
     template<typename T>
-    inline void enable_spying<T>::clear()
+    inline void enable_spying<T>::clear() noexcept
     {
         while(_list_head)
             _list_head->reset();
+    }
+
+    template<typename left_type, typename right_type, typename Base>
+    bool operator ==(const spy_pointer<left_type, Base>& left, const spy_pointer<right_type, Base>& right) noexcept
+    {
+        return static_cast<enable_spying<Base>*>(left.get()) == static_cast<enable_spying<Base>*>(right.get());
     }
 }

--- a/include/libmodules/spy_pointer.hpp
+++ b/include/libmodules/spy_pointer.hpp
@@ -19,6 +19,7 @@ License.
 
 #include "linked_list.hpp"
 
+#include <type_traits>
 #include <utility>
 
 namespace mtl
@@ -84,6 +85,7 @@ namespace mtl
     class spy_pointer final
         : private enable_linking_in_list<spy_pointer<object_base>>
     {
+        static_assert(std::is_base_of_v<object_base, object_type>, "The spy pointer should be specified by derived and base classes.");
     public:
         using base_type = enable_linking_in_list<spy_pointer<object_base>>;
         using type = spy_pointer<object_type, object_base>;

--- a/include/libmodules/spy_pointer.hpp
+++ b/include/libmodules/spy_pointer.hpp
@@ -39,11 +39,11 @@ namespace mtl
     // implement required behavior. The spy pointer template should be specialized by pointer
     // object type.
 
-    template<typename T, typename Base = T>
+    template<typename object_type, typename object_base = object_type>
     class spy_pointer;
 
     // Template specialization is used to resolve ambiguous calls in case of multiple inheritance.
-    template<typename T>
+    template<typename object_type>
     class enable_spying
     {
     public:
@@ -59,11 +59,11 @@ namespace mtl
         // was copied or moved.
         enable_spying() noexcept = default;
         ~enable_spying() noexcept { clear(); }
-        explicit enable_spying(const enable_spying<T>&other) noexcept {}
-        explicit enable_spying(enable_spying<T> && other) noexcept { other.clear(); }
+        explicit enable_spying(const enable_spying<object_type>&other) noexcept {}
+        explicit enable_spying(enable_spying<object_type> && other) noexcept { other.clear(); }
 
-        enable_spying<T>& operator =(const enable_spying<T>&other) noexcept { return *this; }
-        enable_spying<T>& operator =(enable_spying<T> && other) noexcept { other.clear(); return *this; }
+        enable_spying<object_type>& operator =(const enable_spying<object_type>&other) noexcept { return *this; }
+        enable_spying<object_type>& operator =(enable_spying<object_type> && other) noexcept { other.clear(); return *this; }
 
         // Child type could by notified when it has new spy or lose the last one. It could overload
         // this signal to perform some specific actions.
@@ -73,28 +73,28 @@ namespace mtl
 
     private:
         // Pointers should be able to add itself in the linked list
-        template<typename PointerType, typename Base>
+        template<typename PointerType, typename object_base>
         friend class spy_pointer;
 
         // List head could be modified in constant object
-        mutable spy_pointer<T>* _list_head = nullptr;
+        mutable spy_pointer<object_type>* _list_head = nullptr;
     };
 
-    template<typename T, typename Base>
+    template<typename object_type, typename object_base>
     class spy_pointer final
-        : private enable_linking_in_list<spy_pointer<Base>>
+        : private enable_linking_in_list<spy_pointer<object_base>>
     {
     public:
-        using base_type = enable_linking_in_list<spy_pointer<Base>>;
-        using type = spy_pointer<T, Base>;
+        using base_type = enable_linking_in_list<spy_pointer<object_base>>;
+        using type = spy_pointer<object_type, object_base>;
 
-        spy_pointer(T* p_object = nullptr) noexcept
+        spy_pointer(object_type* p_object = nullptr) noexcept
             : _p_object(p_object)
         {
             if (!_p_object)
                 return;
 
-            enable_spying<Base>* tmp = _p_object;
+            enable_spying<object_base>* tmp = _p_object;
             // Place the pointer at the head of the linked list
             this->insert(tmp->_list_head);
             // If it is the first spy we should notify the object
@@ -112,20 +112,20 @@ namespace mtl
             // There should no any spy pointed to the object while we notifying the object
             // Yes, this object also should be released
             // So, we clen member pointer before we call notification callback
-            enable_spying<Base>* tmp = _p_object;
+            enable_spying<object_base>* tmp = _p_object;
             _p_object = nullptr;
             if (!tmp->_list_head)
                 tmp->on_spying_state_changed();
         }
 
         template<typename other_type>
-        type& swap(spy_pointer<other_type, Base>& other) noexcept
+        type& swap(spy_pointer<other_type, object_base>& other) noexcept
         {
             // Swap linked lists
             base_type::swap(other);
             // Then swap pointers
-            enable_spying<Base>* tmp = _p_object;
-            _p_object = static_cast<T*>(other._p_object);
+            enable_spying<object_base>* tmp = _p_object;
+            _p_object = static_cast<object_type*>(other._p_object);
             other._p_object = static_cast<other_type*>(tmp);
 
             return *this;
@@ -134,30 +134,30 @@ namespace mtl
         // The rest of copy constructors, copy operators and other operations
         explicit spy_pointer(const type&  other) noexcept : spy_pointer(other._p_object) {}
         template<typename other_type>
-        explicit spy_pointer(const spy_pointer<other_type, Base>&  other) noexcept : spy_pointer(static_cast<T*>(other._p_object)) {}
+        explicit spy_pointer(const spy_pointer<other_type, object_base>&  other) noexcept : spy_pointer(static_cast<object_type*>(other._p_object)) {}
 
-        explicit spy_pointer(type&& other) noexcept { swap(other); }
+        explicit spy_pointer(type&& other) noexcept                                   {                                    swap(other); }
         template<typename other_type>
-        explicit spy_pointer(spy_pointer<other_type, Base>&& other) noexcept { swap(other); }
+        explicit spy_pointer(spy_pointer<other_type, object_base>&& other) noexcept   {                                    swap(other); }
 
-        type& operator =(const type&  other) noexcept { type tmp(other);                                     return swap(tmp); }
-        type& operator =(      type&& other) noexcept { type tmp(std::move(other));                          return swap(tmp); }
+        type& operator =(const type&  other) noexcept                                 { type tmp(other);            return swap(tmp); }
+        type& operator =(      type&& other) noexcept                                 { type tmp(std::move(other)); return swap(tmp); }
         template<typename other_type>
-        type& operator =(const spy_pointer<other_type, Base>&  other) noexcept { type tmp(other);            return swap(tmp); }
+        type& operator =(const spy_pointer<other_type, object_base>&  other) noexcept { type tmp(other);            return swap(tmp); }
         template<typename other_type>
-        type& operator =(      spy_pointer<other_type, Base>&& other) noexcept { type tmp(std::move(other)); return swap(tmp); }
+        type& operator =(      spy_pointer<other_type, object_base>&& other) noexcept { type tmp(std::move(other)); return swap(tmp); }
 
         template<typename other_type>
-        operator spy_pointer<other_type, Base>() const noexcept { return spy_pointer<other_type, Base>(*this); }
+        operator spy_pointer<other_type, object_base>() const noexcept { return spy_pointer<other_type, object_base>(*this); }
 
-        type& reset(     T* p_object = nullptr) noexcept { type tmp(p_object); return swap(tmp); }
-        type& operator =(T* p_object)           noexcept { return reset(p_object); }
+        type& reset(     object_type* p_object = nullptr) noexcept { type tmp(p_object); return swap(tmp); }
+        type& operator =(object_type* p_object)           noexcept { return reset(p_object); }
         
-        operator bool() const noexcept { return !!_p_object; }
-        T* operator->() const noexcept { return   _p_object; }
-        T& operator *() const noexcept { return  *_p_object; }
-        T* get()        const noexcept { return   _p_object; }
-        operator   T*() const noexcept { return   _p_object; }
+        operator bool()           const noexcept { return !!_p_object; }
+        object_type* operator->() const noexcept { return   _p_object; }
+        object_type& operator *() const noexcept { return  *_p_object; }
+        object_type* get()        const noexcept { return   _p_object; }
+        operator   object_type*() const noexcept { return   _p_object; }
 
     private:
         // Pointers could point to different type casts of one object
@@ -166,21 +166,21 @@ namespace mtl
         // Object should be able to release the pointer and exclude it from the list
         friend base_type;
 
-        T* _p_object = nullptr;
+        object_type* _p_object = nullptr;
     };
 
     // The clear method has to be defined after the spy_pointer class definition to be able access
     // it's members.
-    template<typename T>
-    inline void enable_spying<T>::clear() noexcept
+    template<typename object_type>
+    inline void enable_spying<object_type>::clear() noexcept
     {
         while(_list_head)
             _list_head->reset();
     }
 
-    template<typename left_type, typename right_type, typename Base>
-    bool operator ==(const spy_pointer<left_type, Base>& left, const spy_pointer<right_type, Base>& right) noexcept
+    template<typename left_type, typename right_type, typename object_base>
+    bool operator ==(const spy_pointer<left_type, object_base>& left, const spy_pointer<right_type, object_base>& right) noexcept
     {
-        return static_cast<enable_spying<Base>*>(left.get()) == static_cast<enable_spying<Base>*>(right.get());
+        return static_cast<enable_spying<object_base>*>(left.get()) == static_cast<enable_spying<object_base>*>(right.get());
     }
 }

--- a/include/libmodules/spy_pointer.hpp
+++ b/include/libmodules/spy_pointer.hpp
@@ -85,7 +85,7 @@ namespace mtl
     class spy_pointer final
         : private enable_linking_in_list<spy_pointer<object_base>>
     {
-        static_assert(std::is_base_of_v<object_base, object_type>, "The spy pointer should be specified by derived and base classes.");
+        static_assert(std::is_base_of<object_base, object_type>::value, "The spy pointer should be specified by derived and base classes.");
     public:
         using base_type = enable_linking_in_list<spy_pointer<object_base>>;
         using type = spy_pointer<object_type, object_base>;

--- a/test/spy_pointer_test.cpp
+++ b/test/spy_pointer_test.cpp
@@ -25,7 +25,7 @@ struct SpiedObject
     : public enable_spying<SpiedObject>
 {
     bool empty_state_in_callback = true;
-    virtual void on_spying_state_changed() { empty_state_in_callback = empty(); }
+    virtual void on_spying_state_changed() noexcept { empty_state_in_callback = empty(); }
 };
 
 struct ChildObject


### PR DESCRIPTION
#Brief desctiption

[C++ core guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines.html) were applied to `spy_pointer` class.

Some improvements wer applied to already changed files.