### PR TITLE
Spy pointer polising

### DIFF
--- a/include/libmodules/linked_list.hpp
+++ b/include/libmodules/linked_list.hpp
@@ -81,7 +81,7 @@ namespace mtl
             list = static_cast<next_pointer>(this);
         }
 
-        reference swap(reference other) noexcept
+        void swap(reference other) noexcept
         {
             // Swap content
             // It isn't a simple operation due to ceases when neighborhoods are swapped
@@ -103,7 +103,6 @@ namespace mtl
                 _next->_prev = &_next;
             if (other._next)
                 other._next->_prev = &other._next;
-            return *this;
         }
 
         // The rest of copy constructors, copy operators and other operations
@@ -112,11 +111,11 @@ namespace mtl
         explicit enable_linking_in_list(const reference     prev)  noexcept : enable_linking_in_list(prev._next) {}
         explicit enable_linking_in_list(      rvalue        other) noexcept { swap(other); }
         reference operator=            (const reference     prev)  noexcept { return insert_after(prev); }
-        reference operator=            (      rvalue        other) noexcept { type tmp(std::move(other)); return swap(tmp); }
-        reference insert               (      next_pointer& list)  noexcept { type tmp(list);             return swap(tmp); }
-        reference insert_after         (const reference     prev)  noexcept { type tmp(prev);             return swap(tmp); }
-        reference insert_before        (const reference     next)  noexcept { insert_after(next);         return swap(next); }
-        reference unlink()                                         noexcept { type tmp;                   return swap(tmp); }
+        reference operator=            (      rvalue        other) noexcept { type tmp(std::move(other)); swap(tmp);  return *this;}
+        reference insert               (      next_pointer& list)  noexcept { type tmp(list);             swap(tmp);  return *this;}
+        reference insert_after         (const reference     prev)  noexcept { type tmp(prev);             swap(tmp);  return *this;}
+        reference insert_before        (const reference     next)  noexcept { insert_after(next);         swap(next); return *this;}
+        reference unlink()                                         noexcept { type tmp;                   swap(tmp);  return *this;}
 
         // These getters allow to iterate down by linked list.
         // Constant object do not removes constant access.

--- a/include/libmodules/spy_pointer.hpp
+++ b/include/libmodules/spy_pointer.hpp
@@ -84,7 +84,7 @@ namespace mtl
 
         // List head could be modified in constant object
         mutable spy_pointer<object_type>* _list_head = nullptr;
-    };
+    }; // class enable_spying
 
     template<typename object_type, typename object_base>
     class spy_pointer final
@@ -174,7 +174,7 @@ namespace mtl
         friend base_type;
 
         object_type* _p_object = nullptr;
-    };
+    }; // class spy_pointer
 
     // The clear method has to be defined after the spy_pointer class definition to be able access
     // it's members.
@@ -189,5 +189,11 @@ namespace mtl
     bool operator ==(const spy_pointer<left_type, object_base>& left, const spy_pointer<right_type, object_base>& right) noexcept
     {
         return static_cast<enable_spying<object_base>*>(left.get()) == static_cast<enable_spying<object_base>*>(right.get());
+    }
+
+    template<typename first_type, typename second_type, typename object_base>
+	void swap(spy_pointer<first_type, object_base>& first, spy_pointer<second_type, object_base>& second) noexcept
+    {
+        first.swap(second);
     }
 }

--- a/include/libmodules/spy_pointer.hpp
+++ b/include/libmodules/spy_pointer.hpp
@@ -126,7 +126,7 @@ namespace mtl
         }
 
         template<typename other_type>
-        type& swap(spy_pointer<other_type, object_base>& other) noexcept
+        void swap(spy_pointer<other_type, object_base>& other) noexcept
         {
             // Swap linked lists
             base_type::swap(other);
@@ -134,8 +134,6 @@ namespace mtl
             enable_spying<object_base>* tmp = _p_object;
             _p_object = static_cast<object_type*>(other._p_object);
             other._p_object = static_cast<other_type*>(tmp);
-
-            return *this;
         }
 
         // The rest of copy constructors, copy operators and other operations
@@ -147,17 +145,17 @@ namespace mtl
         template<typename other_type>
         explicit spy_pointer(spy_pointer<other_type, object_base>&& other) noexcept   {                                    swap(other); }
 
-        type& operator =(const type&  other) noexcept                                 { type tmp(other);            return swap(tmp); }
-        type& operator =(      type&& other) noexcept                                 { type tmp(std::move(other)); return swap(tmp); }
+        type& operator =(const type&  other) noexcept                                 { type tmp(other);            swap(tmp); return *this; }
+        type& operator =(      type&& other) noexcept                                 { type tmp(std::move(other)); swap(tmp); return *this; }
         template<typename other_type>
-        type& operator =(const spy_pointer<other_type, object_base>&  other) noexcept { type tmp(other);            return swap(tmp); }
+        type& operator =(const spy_pointer<other_type, object_base>&  other) noexcept { type tmp(other);            swap(tmp); return *this; }
         template<typename other_type>
-        type& operator =(      spy_pointer<other_type, object_base>&& other) noexcept { type tmp(std::move(other)); return swap(tmp); }
+        type& operator =(      spy_pointer<other_type, object_base>&& other) noexcept { type tmp(std::move(other)); swap(tmp); return *this; }
 
         template<typename other_type>
         operator spy_pointer<other_type, object_base>() const noexcept { return spy_pointer<other_type, object_base>(*this); }
 
-        type& reset(     object_type* p_object = nullptr) noexcept { type tmp(p_object); return swap(tmp); }
+        type& reset(     object_type* p_object = nullptr) noexcept { type tmp(p_object); swap(tmp); return *this; }
         type& operator =(object_type* p_object)           noexcept { return reset(p_object); }
         
         operator bool()           const noexcept { return !!_p_object; }

--- a/include/libmodules/spy_pointer.hpp
+++ b/include/libmodules/spy_pointer.hpp
@@ -58,7 +58,12 @@ namespace mtl
         // of linked list from other object, but clears other object in case if it was moved. It
         // means that spy pointer operates like regular pointer and do not follow to object if it
         // was copied or moved.
-        enable_spying() noexcept = default;
+        enable_spying() noexcept
+        {
+            // Types should be defined to call `std::is_base_of`.
+            static_assert(std::is_base_of<enable_spying, object_type>::value, "The enable_spying template should be specified by derived class type.");
+        };
+
         ~enable_spying() noexcept { clear(); }
         explicit enable_spying(const enable_spying<object_type>&other) noexcept {}
         explicit enable_spying(enable_spying<object_type> && other) noexcept { other.clear(); }

--- a/include/libmodules/spy_pointer.hpp
+++ b/include/libmodules/spy_pointer.hpp
@@ -192,7 +192,7 @@ namespace mtl
     }
 
     template<typename first_type, typename second_type, typename object_base>
-	void swap(spy_pointer<first_type, object_base>& first, spy_pointer<second_type, object_base>& second) noexcept
+    void swap(spy_pointer<first_type, object_base>& first, spy_pointer<second_type, object_base>& second) noexcept
     {
         first.swap(second);
     }

--- a/test/spy_pointer_test.cpp
+++ b/test/spy_pointer_test.cpp
@@ -43,6 +43,17 @@ TEST(spying, can_dereference_spy)
     EXPECT_TRUE(obj.state);
 }
 
+TEST(spying, can_swap_spys)
+{
+    ChildObject obj;
+    spy_pointer<ChildObject, SpiedObject> first(&obj);
+    spy_pointer<ChildObject, SpiedObject> second;
+    
+    swap(first, second);
+    EXPECT_FALSE(first);
+    EXPECT_TRUE(second);
+}
+
 TEST(spying, can_detect_spied_object_destruction)
 {
     spy_pointer<SpiedObject> spy;


### PR DESCRIPTION
# Brief description

The `spy_pointer` template was polised. Extra `swap` fuction was added. The member `swap` function return value was changed to follow standard.

The `linked_list` member `swap` function return value was changed to follow standard.