### PR TITLE
Enable C++ 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.4)
 project(libmodules)
 
-set (CMAKE_CXX_STANDARD 11)
+set (CMAKE_CXX_STANDARD 20)
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/dependencies/cmake-modules")
 set(gtest_force_shared_crt ON)
 

--- a/include/libmodules/linked_list.hpp
+++ b/include/libmodules/linked_list.hpp
@@ -70,7 +70,7 @@ namespace mtl
         explicit enable_linking_in_list(next_pointer& list) noexcept
         {
             // This assert is placed here to delay check until parent object is created.
-            static_assert(std::is_base_of<enable_linking_in_list<object_type>, object_type>::value,
+            static_assert(std::is_base_of_v<enable_linking_in_list<object_type>, object_type>,
                           "enable_linking_in_list should be base of template parameter type");
             // Place self into the list head
             _prev = &list;

--- a/include/libmodules/spy_pointer.hpp
+++ b/include/libmodules/spy_pointer.hpp
@@ -61,7 +61,7 @@ namespace mtl
         enable_spying() noexcept
         {
             // Types should be defined to call `std::is_base_of`.
-            static_assert(std::is_base_of<enable_spying, object_type>::value, "The enable_spying template should be specified by derived class type.");
+            static_assert(std::is_base_of_v<enable_spying, object_type>, "The enable_spying template should be specified by derived class type.");
         };
 
         ~enable_spying() noexcept { clear(); }
@@ -90,7 +90,7 @@ namespace mtl
     class spy_pointer final
         : private enable_linking_in_list<spy_pointer<object_base>>
     {
-        static_assert(std::is_base_of<object_base, object_type>::value, "The spy pointer should be specified by derived and base classes.");
+        static_assert(std::is_base_of_v<object_base, object_type>, "The spy pointer should be specified by derived and base classes.");
     public:
         using base_type = enable_linking_in_list<spy_pointer<object_base>>;
         using type = spy_pointer<object_type, object_base>;

--- a/test/emitter_test.cpp
+++ b/test/emitter_test.cpp
@@ -309,35 +309,37 @@ TEST(emitting, emitter_can_detach_all_while_sending)
 TEST(emitting, can_delete_receiver_while_sending)
 {
     emitter<test_emitter_signals> em;
-    test_receiver* r = new test_receiver();
+    auto r = make_shared<test_receiver>();
     
     em.attach(*r);
-    shared_ptr<void> obj = shared_ptr<test_receiver>(r);
+	shared_ptr<void> obj{ move(r) };
     EXPECT_TRUE(em.send(&test_emitter_signals::delete_obj, ref(obj)));
     EXPECT_TRUE(em.empty());
 }
 
 TEST(emitting, can_delete_emitter_while_sending)
 {
-    emitter<test_emitter_signals>* em = new emitter<test_emitter_signals>();
+    auto em = make_shared<emitter<test_emitter_signals>>();
+    auto* em_ptr = em.get();
     test_receiver r;
     
     em->attach(r);
-    shared_ptr<void> obj = shared_ptr<emitter<test_emitter_signals>>(em);
-    EXPECT_FALSE(em->send(&test_emitter_signals::delete_obj, ref(obj)));
+    shared_ptr<void> obj{ move(em) };
+    EXPECT_FALSE(em_ptr->send(&test_emitter_signals::delete_obj, ref(obj)));
     EXPECT_TRUE(r.empty());
 }
 
 TEST(emitting, can_delete_emitter_while_recursive_sending)
 {
-    emitter<test_emitter_signals>* em = new emitter<test_emitter_signals>();
+    auto em = make_shared<emitter<test_emitter_signals>>();
+    auto* em_ptr = em.get();
     test_receiver r;
     
     em->attach(r);
 
-    shared_ptr<void> obj = shared_ptr<emitter<test_emitter_signals>>(em);
+    shared_ptr<void> obj{ move(em) };
     packed_signal<test_emitter_signals> signal(bind(&test_emitter_signals::delete_obj, placeholders::_1, ref(obj)));
-    EXPECT_FALSE(em->send(&test_emitter_signals::send_signal, ref(*em), signal));
+    EXPECT_FALSE(em_ptr->send(&test_emitter_signals::send_signal, ref(*em_ptr), signal));
     EXPECT_TRUE(r.empty());
 }
 

--- a/test/proxy_receiver_test.cpp
+++ b/test/proxy_receiver_test.cpp
@@ -104,7 +104,7 @@ TEST(filter_proxy_receiver, can_filter_signal)
 
 TEST(filter_proxy_receiver, can_be_destroyed_by_filter)
 {
-    unique_ptr<test_filter_proxy_receiver> obj(new test_filter_proxy_receiver());
+    auto obj = make_unique<test_filter_proxy_receiver>();
     test_simple_receiver r;
     obj->attach(r);
     EXPECT_NO_FATAL_FAILURE(obj->transmit_signal(packed_signal<test_proxy_receiver_signals>(bind(&test_proxy_receiver_signals::some_signal, placeholders::_1, &obj))));


### PR DESCRIPTION
# Brief description

The C++ 20 standart was enabled in CMake build.
Type treats and memory object handling was improved by using new standard features.